### PR TITLE
add categoryInfoControl

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
@@ -4,6 +4,7 @@ package com.digitalojt.web.consts;
  * URL定数クラス
  *
  * @author Okuma
+ * /admin/categoryInfoControl
  * 
  */
 public class UrlConsts {
@@ -20,6 +21,9 @@ public class UrlConsts {
 	// 在庫一覧画面 検索
 	public static final String STOCK_LIST_SEARCH = "/admin/stockList/search";
 	
+	// 分類情報管理画面
+	public static final String CATEGORY_INFO_CONTROL = "/admin/categoryInfoControl";
+	
 	// 在庫センター情報画面
 	public static final String  CENTER_INFO = "/admin/centerInfo";
 	
@@ -28,4 +32,6 @@ public class UrlConsts {
 	
 	// 認証不要画面
 	public static final String[] NO_AUTHENTICATION = {LOGIN, AUTHENTICATE};
+	
+
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
@@ -1,0 +1,29 @@
+package com.digitalojt.web.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.digitalojt.web.consts.UrlConsts;
+
+/**
+ * 分類情報管理画面のコントローラークラス
+ * 
+ * @author Okuma
+ *
+ */
+@Controller
+public class CategoryInfoControlController extends AbstractController{
+
+	/**
+	 * 初期表示
+	 * 
+	 * @return String(path)
+	 */
+	@GetMapping(UrlConsts.CATEGORY_INFO_CONTROL)
+	public String index() {
+
+		return "admin/categoryInfoControl/index";
+	}
+	
+	
+}

--- a/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html
+  xmlns:th="http://www.thymeleaf.org"
+  th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}"
+>
+  <head>
+    <title>InvenTrack</title>
+  </head>
+
+  <body>
+    <div class="card shadow mb-4">
+      <div class="card-header py-3">
+        <h6 class="m-0 font-weight-bold text-primary">Hello World</h6>
+      </div>
+
+      <div class="card-body">
+        <div class="table-responsive">
+          <table
+            class="table table-bordered"
+            id="dataTable"
+            width="100%"
+            cellspacing="0"
+          >
+          </table>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/DroneInventorySystem/src/main/resources/templates/layout/navbar.html
+++ b/DroneInventorySystem/src/main/resources/templates/layout/navbar.html
@@ -26,7 +26,7 @@
 				<a class="nav-link" th:href="@{'/admin/stockList'}">
 					<span>在庫一覧</span>
 				</a>
-				<a class="nav-link" th:href="@{'/admin/stockList'}">
+				<a class="nav-link" th:href="@{'/admin/categoryInfoControl'}">
 					<span>分類情報管理</span>
 				</a>
 				<a class="nav-link" th:href="@{'/admin/centerInfo'}">


### PR DESCRIPTION
## 概要

分類情報管理画面を初期表示する設定を追加

## 実装方針・詳細

- 分類情報管理画面の追加
　・メニュー画面の「分類情報管理」を押下後の遷移先「分類情報管理画面」を新規作成
　・分類情報管理画面は「Hellow World」のみ表示

## 影響範囲

・他の機能に影響なし

## テスト

-メニュー画面の「分類情報管理」を押下
