### PR TITLE
add categoryConsts

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/CategoryConsts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/CategoryConsts.java
@@ -1,0 +1,29 @@
+package com.digitalojt.web.consts;
+/**
+ * 分類 Enumクラス
+ * 
+ * @author Okuma
+ */
+public enum CategoryConsts {
+
+	FRAME("フレーム"),
+	PROPELLER("プロペラ"),
+	ELECTRICMOTOR("電動モーター"),
+	ELECTRICSPEEDREGULATOR("電子速度調整器"),
+	BATTERY("バッテリー"),
+	FLIGHTCONTROLLER("フライトコントローラー"),
+	REMOTECONTROLLER("リモートコントローラー"),	
+	RECEIVER("受信機"),
+	GPSMODULE("GPSモジュール"),
+	CAMERASENSOR("カメラ／センサー");
+	
+	private final String category;
+
+	CategoryConsts(String category) {
+        this.category = category;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
@@ -1,26 +1,38 @@
 package com.digitalojt.web.controller;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import com.digitalojt.web.consts.CategoryConsts;
 import com.digitalojt.web.consts.UrlConsts;
 
 /**
  * 分類情報管理画面のコントローラークラス
  * 
  * @author Okuma
- *
+ * 
  */
 @Controller
-public class CategoryInfoControlController extends AbstractController{
-
+public class CategoryInfoControlController{
+	
 	/**
 	 * 初期表示
 	 * 
-	 * @return String(path)
+	 * @param model
+	 * @return
 	 */
 	@GetMapping(UrlConsts.CATEGORY_INFO_CONTROL)
-	public String index() {
+	public String index(Model model) {
+		
+		// 分類 Enumをリストに変換
+		List<CategoryConsts> categoryConsts = Arrays.asList(CategoryConsts.values());
+
+		// 分類一覧情報をセット
+		model.addAttribute("categoryConsts", categoryConsts);
 
 		return "admin/categoryInfoControl/index";
 	}

--- a/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
@@ -10,7 +10,7 @@
   <body>
     <div class="card shadow mb-4">
       <div class="card-header py-3">
-        <h6 class="m-0 font-weight-bold text-primary">Hello World</h6>
+        <h6 class="m-0 font-weight-bold text-primary">分類情報管理</h6>
       </div>
 
       <div class="card-body">
@@ -18,9 +18,13 @@
           <table
             class="table table-bordered"
             id="dataTable"
-            width="100%"
-            cellspacing="0"
+            style="width:70%;text-align: center;margin: auto;"
           >
+          	<tbody>
+              <tr th:each="item : ${categoryConsts}">
+				<td> [[${item.category}]] </td>
+              </tr>
+             </tbody>
           </table>
         </div>
       </div>


### PR DESCRIPTION
## 概要

分類情報管理画面の初期表示に分類項目一覧表示を追加

## 実装方針・詳細

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 分類情報管理画面に分類項目一覧表示を追加
　・分類項目を定数クラスに設定
　・分類項目をリスト化し画面に表示

## 影響範囲

・他の機能に影響なし

## テスト

- メニュー画面の「分類情報管理」を押下
