### PR TITLE
add categorySearch

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ErrorMessage.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ErrorMessage.java
@@ -22,4 +22,11 @@ public class ErrorMessage {
 
 	// 文字超過に関するエラーメッセージ
 	public static final String CENTER_NAME_LENGTH_ERROR_MESSAGE = "centerName.length.wrongInput";
+
+	// 文字超過に関するエラーメッセージ
+	public static final String CATEGORY_LENGTH_ERROR_MESSAGE = "category.length.wrongInput";
+
+	// 分類名が空の場合のエラーメッセージ
+	public static final String CATEGORY_FIELDS_EMPTY_ERROR_MESSAGE = "category.empty";
+
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/InvalidCharacter.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/InvalidCharacter.java
@@ -7,7 +7,7 @@ package com.digitalojt.web.consts;
  */
 public enum InvalidCharacter {
 
-    CURLY_BRACE_OPEN('{'),
+	CURLY_BRACE_OPEN('{'),
     CURLY_BRACE_CLOSE('}'),
     PARENTHESIS_OPEN('('),
     PARENTHESIS_CLOSE(')'),
@@ -16,7 +16,10 @@ public enum InvalidCharacter {
     SEMICOLON(';'),
     DOLLAR_SIGN('$'),
     QUESTION_MARK('?'),
-    ASTERISK('*');
+    ASTERISK('*'),
+	HALF_SPACE(' '),
+	SINGLE_QUOTATION('\'');
+	
 
     private final char character;
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/InvalidCharacter.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/InvalidCharacter.java
@@ -8,26 +8,25 @@ package com.digitalojt.web.consts;
 public enum InvalidCharacter {
 
 	CURLY_BRACE_OPEN('{'),
-    CURLY_BRACE_CLOSE('}'),
-    PARENTHESIS_OPEN('('),
-    PARENTHESIS_CLOSE(')'),
-    EQUAL_SIGN('='),
-    AMPERSAND('&'),
-    SEMICOLON(';'),
-    DOLLAR_SIGN('$'),
-    QUESTION_MARK('?'),
-    ASTERISK('*'),
+	CURLY_BRACE_CLOSE('}'),
+	PARENTHESIS_OPEN('('),
+	PARENTHESIS_CLOSE(')'),
+	EQUAL_SIGN('='),
+	AMPERSAND('&'),
+	SEMICOLON(';'),
+	DOLLAR_SIGN('$'),
+	QUESTION_MARK('?'),
+	ASTERISK('*'),
 	HALF_SPACE(' '),
 	SINGLE_QUOTATION('\'');
-	
 
-    private final char character;
+	private final char character;
 
-    InvalidCharacter(char character) {
-        this.character = character;
-    }
+	InvalidCharacter(char character) {
+		this.character = character;
+	}
 
-    public char getCharacter() {
-        return character;
-    }
+	public char getCharacter() {
+		return character;
+	}
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/Limits.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/Limits.java
@@ -1,0 +1,18 @@
+package com.digitalojt.web.consts;
+/**
+ * 制限の定数クラス
+ *
+ * @author Okuma
+ * 
+ * 
+ */
+public class Limits {
+	
+	// 分類名の最大文字数
+	public static final int CATEGORY_MAX_LENGTH = 15;
+	
+	// 在庫センター名の最大文字数
+	public static final int CENTER_INFO_MAX_LENGTH = 20;
+	
+	
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
@@ -4,7 +4,7 @@ package com.digitalojt.web.consts;
  * URL定数クラス
  *
  * @author Okuma
- * /admin/categoryInfoControl
+ * 
  * 
  */
 public class UrlConsts {
@@ -23,6 +23,9 @@ public class UrlConsts {
 	
 	// 分類情報管理画面
 	public static final String CATEGORY_INFO_CONTROL = "/admin/categoryInfoControl";
+	
+	// 分類情報管理画面 検索
+	public static final String CATEGORY_INFO_CONTROL_SEARCH = "/admin/categoryInfoControl/search";
 	
 	// 在庫センター情報画面
 	public static final String  CENTER_INFO = "/admin/centerInfo";

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
@@ -3,12 +3,20 @@ package com.digitalojt.web.controller;
 import java.util.Arrays;
 import java.util.List;
 
+import org.springframework.context.MessageSource;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 
 import com.digitalojt.web.consts.CategoryConsts;
 import com.digitalojt.web.consts.UrlConsts;
+import com.digitalojt.web.form.CategoryInfoControlForm;
+import com.digitalojt.web.util.MessageManager;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 /**
  * 分類情報管理画面のコントローラークラス
@@ -17,7 +25,11 @@ import com.digitalojt.web.consts.UrlConsts;
  * 
  */
 @Controller
+@RequiredArgsConstructor
 public class CategoryInfoControlController{
+	
+	/** メッセージソース */
+	private final MessageSource messageSource;
 	
 	/**
 	 * 初期表示
@@ -30,6 +42,42 @@ public class CategoryInfoControlController{
 		
 		// 分類 Enumをリストに変換
 		List<CategoryConsts> categoryConsts = Arrays.asList(CategoryConsts.values());
+
+		// 分類一覧情報をセット
+		model.addAttribute("categoryConsts", categoryConsts);
+
+		return "admin/categoryInfoControl/index";
+	}
+	
+	/**
+	 * 検索結果表示
+	 * 
+	 * @param model
+	 * @param form
+	 * @return
+	 */
+	@PostMapping(UrlConsts.CATEGORY_INFO_CONTROL_SEARCH)
+	public String search(Model model, @Valid CategoryInfoControlForm form, BindingResult bindingResult) {
+
+		// Valid項目チェック
+		if (bindingResult.hasErrors()) {
+			
+			// エラーメッセージをプロパティファイルから取得
+			String errorMsg = MessageManager.getMessage(messageSource, bindingResult.getGlobalError().getDefaultMessage());
+			model.addAttribute("errorMsg", errorMsg);
+
+			// 分類 Enumをリストに変換
+			List<CategoryConsts> categoryConsts = Arrays.asList(CategoryConsts.values());
+
+			// 分類一覧情報をセット
+			model.addAttribute("categoryConsts", categoryConsts);
+
+			return "admin/categoryInfoControl/index";
+		}
+		
+
+		// 分類情報管理画面に表示するデータを取得
+		List<CategoryConsts> categoryConsts = form.getCategoryResearchResult(form.getCategory());
 
 		// 分類一覧情報をセット
 		model.addAttribute("categoryConsts", categoryConsts);

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CategoryInfoControlForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CategoryInfoControlForm.java
@@ -1,0 +1,43 @@
+package com.digitalojt.web.form;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.digitalojt.web.consts.CategoryConsts;
+import com.digitalojt.web.validation.CategoryInfoControlFormValidator;
+
+import lombok.Data;
+
+/**
+ * 分類情報管理画面のフォームクラス
+ * 
+ * @author Okuma
+ *
+ */
+@Data
+@CategoryInfoControlFormValidator
+public class CategoryInfoControlForm {
+	
+	/**
+	 * 分類名
+	 */
+	private String category;
+	
+	/**
+	 * 引数に合致する分類情報を取得
+	 * 
+	 * @param category
+	 * @return
+	 */
+	public List<CategoryConsts> getCategoryResearchResult(String category) {
+		
+		List<CategoryConsts> categoryResearchResult = new ArrayList<>();
+		for (CategoryConsts CategoryConsts : CategoryConsts.values()) {
+            if (CategoryConsts.getCategory().equals(category)) {
+            	categoryResearchResult.add(CategoryConsts);
+            }
+		}
+		return categoryResearchResult;
+	}
+	
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CategoryInfoControlForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/CategoryInfoControlForm.java
@@ -17,12 +17,12 @@ import lombok.Data;
 @Data
 @CategoryInfoControlFormValidator
 public class CategoryInfoControlForm {
-	
+
 	/**
 	 * 分類名
 	 */
 	private String category;
-	
+
 	/**
 	 * 引数に合致する分類情報を取得
 	 * 
@@ -30,14 +30,14 @@ public class CategoryInfoControlForm {
 	 * @return
 	 */
 	public List<CategoryConsts> getCategoryResearchResult(String category) {
-		
+
 		List<CategoryConsts> categoryResearchResult = new ArrayList<>();
 		for (CategoryConsts CategoryConsts : CategoryConsts.values()) {
-            if (CategoryConsts.getCategory().equals(category)) {
-            	categoryResearchResult.add(CategoryConsts);
-            }
+			if (CategoryConsts.getCategory().equals(category)) {
+				categoryResearchResult.add(CategoryConsts);
+			}
 		}
 		return categoryResearchResult;
 	}
-	
+
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoControlFormValidator.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoControlFormValidator.java
@@ -1,0 +1,26 @@
+package com.digitalojt.web.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.digitalojt.web.consts.ErrorMessage;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+/**
+ * 分類情報管理画面のバリデーションチェック インターフェース
+ * 
+ * @author Okuma
+ */
+@Constraint(validatedBy = CategoryInfoControlFormValidatorImpl.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CategoryInfoControlFormValidator {
+
+	String message() default ErrorMessage.ALL_FIELDS_EMPTY_ERROR_MESSAGE;
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoControlFormValidator.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoControlFormValidator.java
@@ -21,6 +21,8 @@ import jakarta.validation.Payload;
 public @interface CategoryInfoControlFormValidator {
 
 	String message() default ErrorMessage.ALL_FIELDS_EMPTY_ERROR_MESSAGE;
-    Class<?>[] groups() default {};
-    Class<? extends Payload>[] payload() default {};
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoControlFormValidatorImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoControlFormValidatorImpl.java
@@ -3,6 +3,7 @@ package com.digitalojt.web.validation;
 import org.thymeleaf.util.StringUtils;
 
 import com.digitalojt.web.consts.ErrorMessage;
+import com.digitalojt.web.consts.Limits;
 import com.digitalojt.web.form.CategoryInfoControlForm;
 import com.digitalojt.web.util.ParmCheckUtil;
 
@@ -23,7 +24,7 @@ public class CategoryInfoControlFormValidatorImpl implements ConstraintValidator
 	public boolean isValid(CategoryInfoControlForm form, ConstraintValidatorContext context) {
 
 		// 最大文字数
-		final int MAX_LENGTH = 15;
+		int MAX_LENGTH = Limits.CATEGORY_MAX_LENGTH;
 
 		boolean allFieldsEmpty = StringUtils.isEmpty(form.getCategory());
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoControlFormValidatorImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CategoryInfoControlFormValidatorImpl.java
@@ -1,0 +1,61 @@
+package com.digitalojt.web.validation;
+
+import org.thymeleaf.util.StringUtils;
+
+import com.digitalojt.web.consts.ErrorMessage;
+import com.digitalojt.web.form.CategoryInfoControlForm;
+import com.digitalojt.web.util.ParmCheckUtil;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * 分類情報管理画面のバリデーションチェック 実装クラス
+ * 
+ * @author Okuma
+ */
+public class CategoryInfoControlFormValidatorImpl implements ConstraintValidator<CategoryInfoControlFormValidator, CategoryInfoControlForm>  {
+
+	/**
+	 * バリデーションチェック
+	 */
+	@Override
+	public boolean isValid(CategoryInfoControlForm form, ConstraintValidatorContext context) {
+
+		// 最大文字数
+		final int MAX_LENGTH = 15;
+
+		boolean allFieldsEmpty = StringUtils.isEmpty(form.getCategory());
+
+		// 分類名フィールドが空かをチェック
+		if (allFieldsEmpty) {
+			context.disableDefaultConstraintViolation();
+			context.buildConstraintViolationWithTemplate(ErrorMessage.CATEGORY_FIELDS_EMPTY_ERROR_MESSAGE)
+					.addConstraintViolation();
+			return false;
+		}
+
+		// 分類名のチェック
+		if (form.getCategory() != null) {
+
+			// 不正文字列チェック
+			if (ParmCheckUtil.isParameterInvalid(form.getCategory())) {
+				context.disableDefaultConstraintViolation();
+				context.buildConstraintViolationWithTemplate(ErrorMessage.INVALID_INPUT_ERROR_MESSAGE)
+						.addConstraintViolation();
+				return false;
+			}
+
+			// 文字数チェック
+			if (form.getCategory().length() > MAX_LENGTH) {
+				context.disableDefaultConstraintViolation();
+				context.buildConstraintViolationWithTemplate(ErrorMessage.CATEGORY_LENGTH_ERROR_MESSAGE)
+						.addConstraintViolation();
+				return false;
+			}
+		}
+
+		// その他のバリデーションに問題なければtrueを返す
+		return true;
+	}
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CenterInfoFormValidatorImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/CenterInfoFormValidatorImpl.java
@@ -3,6 +3,7 @@ package com.digitalojt.web.validation;
 import org.thymeleaf.util.StringUtils;
 
 import com.digitalojt.web.consts.ErrorMessage;
+import com.digitalojt.web.consts.Limits;
 import com.digitalojt.web.form.CenterInfoForm;
 import com.digitalojt.web.util.ParmCheckUtil;
 
@@ -23,7 +24,7 @@ public class CenterInfoFormValidatorImpl implements ConstraintValidator<CenterIn
 	public boolean isValid(CenterInfoForm form, ConstraintValidatorContext context) {
 
 		// 最大文字数
-		final int MAX_LENGTH = 20;
+		int MAX_LENGTH = Limits.CENTER_INFO_MAX_LENGTH;
 
 		boolean allFieldsEmpty = StringUtils.isEmpty(form.getCenterName()) &&
 				StringUtils.isEmpty(form.getRegion());
@@ -48,10 +49,6 @@ public class CenterInfoFormValidatorImpl implements ConstraintValidator<CenterIn
 			}
 
 			// 文字数チェック
-			/**
-			 *  TODO:Formクラスをシンプルにしたく、@Sizeを使わずこちらで桁数チェックを行いました。
-			 *  	 車輪の再発明なので、しないほうがいいでしょうか？
-			 */
 			if (form.getCenterName().length() > MAX_LENGTH) {
 				context.disableDefaultConstraintViolation();
 				context.buildConstraintViolationWithTemplate(ErrorMessage.CENTER_NAME_LENGTH_ERROR_MESSAGE)

--- a/DroneInventorySystem/src/main/resources/messages.properties
+++ b/DroneInventorySystem/src/main/resources/messages.properties
@@ -9,5 +9,9 @@ login.wrongInput=管理者IDとパスワードの組み合わせが間違って�
 # 在庫センター情報画面
 centerName.length.wrongInput=センター名は20文字以内で入力してください。
 
+# 分類情報管理画面
+category.length.wrongInput=分類名は1文字以上15文字以内で入力してください。
+category.empty=分類名を入力してください。
+
 # Spring Security が拾う例外のエラーメッセージをカスタマイズ
 AbstractUserDetailsAuthenticationProvider.badCredentials=管理者IDとパスワードの組み合わせが間違っています。

--- a/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
@@ -9,16 +9,38 @@
 
   <body>
     <div class="card shadow mb-4">
+    
       <div class="card-header py-3">
         <h6 class="m-0 font-weight-bold text-primary">分類情報管理</h6>
       </div>
 
-      <div class="card-body">
-        <div class="table-responsive">
+      <div class="card-body" style="width:70%;margin: auto;">
+      
+     	 <!-- 検索フォーム -->
+		<div class="search-container">
+			<form class="form-inline" method="post"
+			 th:action="@{'/admin/categoryInfoControl/search'}"
+			 th:object="${CategoryInfoControlForm}"
+			>
+				<label for="searchTerm" class="mr-3" style="text-decoration : underline;">検索条件</label>
+					
+				<label for="searchTerm" class="mr-2">分類名</label>
+ 				<input type="text" id="searchTerm" name="category" class="form-control mr-3">
+					
+ 				<button type="submit" class="btn btn-primary">検索</button>
+ 			</form>
+ 				
+ 			<!-- エラーメッセージの表示 -->
+ 			<div th:if="${errorMsg != null}" class="text-danger">
+				 <p th:text="${errorMsg}"></p>
+			</div>
+		</div>
+			
+		<!-- 分類情報テーブル -->	
+        <div class="table-responsive"style="text-align: center;">
           <table
             class="table table-bordered"
             id="dataTable"
-            style="width:70%;text-align: center;margin: auto;"
           >
           	<tbody>
               <tr th:each="item : ${categoryConsts}">

--- a/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
@@ -1,55 +1,49 @@
 <!DOCTYPE html>
-<html
-  xmlns:th="http://www.thymeleaf.org"
-  th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}"
->
-  <head>
-    <title>InvenTrack</title>
-  </head>
+<html xmlns:th="http://www.thymeleaf.org"
+	th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}">
+<head>
+<title>InvenTrack</title>
+</head>
 
-  <body>
-    <div class="card shadow mb-4">
-    
-      <div class="card-header py-3">
-        <h6 class="m-0 font-weight-bold text-primary">分類情報管理</h6>
-      </div>
+<body>
+	<div class="card shadow mb-4">
 
-      <div class="card-body" style="width:70%;margin: auto;">
-      
-     	 <!-- 検索フォーム -->
-		<div class="search-container">
-			<form class="form-inline" method="post"
-			 th:action="@{'/admin/categoryInfoControl/search'}"
-			 th:object="${CategoryInfoControlForm}"
-			>
-				<label for="searchTerm" class="mr-3" style="text-decoration : underline;">検索条件</label>
-					
-				<label for="searchTerm" class="mr-2">分類名</label>
- 				<input type="text" id="searchTerm" name="category" class="form-control mr-3">
-					
- 				<button type="submit" class="btn btn-primary">検索</button>
- 			</form>
- 				
- 			<!-- エラーメッセージの表示 -->
- 			<div th:if="${errorMsg != null}" class="text-danger">
-				 <p th:text="${errorMsg}"></p>
+		<div class="card-header py-3">
+			<h6 class="m-0 font-weight-bold text-primary">分類情報管理</h6>
+		</div>
+
+		<div class="card-body" style="width: 70%; margin: auto;">
+
+			<!-- 検索フォーム -->
+			<div class="search-container">
+				<form class="form-inline" method="post"
+					th:action="@{'/admin/categoryInfoControl/search'}"
+					th:object="${CategoryInfoControlForm}">
+					<label for="searchTerm" class="mr-3"
+						style="text-decoration: underline;">検索条件</label>
+					<label for="searchTerm" class="mr-2">分類名</label>
+					<input type="text"id="searchTerm" name="category" class="form-control mr-3">
+
+					<button type="submit" class="btn btn-primary">検索</button>
+				</form>
+
+				<!-- エラーメッセージの表示 -->
+				<div th:if="${errorMsg != null}" class="text-danger">
+					<p th:text="${errorMsg}"></p>
+				</div>
+			</div>
+
+			<!-- 分類情報テーブル -->
+			<div class="table-responsive" style="text-align: center;">
+				<table class="table table-bordered" id="dataTable">
+					<tbody>
+						<tr th:each="item : ${categoryConsts}">
+							<td>[[${item.category}]]</td>
+						</tr>
+					</tbody>
+				</table>
 			</div>
 		</div>
-			
-		<!-- 分類情報テーブル -->	
-        <div class="table-responsive"style="text-align: center;">
-          <table
-            class="table table-bordered"
-            id="dataTable"
-          >
-          	<tbody>
-              <tr th:each="item : ${categoryConsts}">
-				<td> [[${item.category}]] </td>
-              </tr>
-             </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-  </body>
+	</div>
+</body>
 </html>


### PR DESCRIPTION
## 概要

分類情報管理画面に分類名検索機能を追加

## 実装方針・詳細

- 分類名検索機能を追加
　・検索ワード入力用インプットボックスを追加
　・検索ボタンを追加
　・検索時の入力チェックを追加
　・入力チェックに該当する場合　再検索を促すエラーメッセージを表示
　・入力された文字列と分類情報リストの分類名が一致する分類名のみ表示

## 影響範囲

不正文字を管理するEnumクラスに文字列「'」「(半角スペース)」を追加したため、
「在庫センター情報」で追加文字が入力されて検索された場合にエラーメッセージを表示するようになった。

## テスト

- 分類名を検索（例：プロペラ）
- 文字数超過で検索（例：フライト兼リモートコントローラー）
- 空欄で検索
- 不正文字を追加して検索（例：フライト兼リモートコントローラー）
