### PR TITLE
add fetchCategoryFromTheDatabase

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
@@ -12,7 +12,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 
 import com.digitalojt.web.consts.CategoryConsts;
 import com.digitalojt.web.consts.UrlConsts;
+import com.digitalojt.web.entity.CategoryInfo;
 import com.digitalojt.web.form.CategoryInfoControlForm;
+import com.digitalojt.web.service.CategoryInfoService;
 import com.digitalojt.web.util.MessageManager;
 
 import jakarta.validation.Valid;
@@ -26,11 +28,14 @@ import lombok.RequiredArgsConstructor;
  */
 @Controller
 @RequiredArgsConstructor
-public class CategoryInfoControlController{
-	
+public class CategoryInfoControlController {
+
+	/** 分類情報 サービス */
+	private final CategoryInfoService categoryInfoService;
+
 	/** メッセージソース */
 	private final MessageSource messageSource;
-	
+
 	/**
 	 * 初期表示
 	 * 
@@ -39,16 +44,23 @@ public class CategoryInfoControlController{
 	 */
 	@GetMapping(UrlConsts.CATEGORY_INFO_CONTROL)
 	public String index(Model model) {
-		
-		// 分類 Enumをリストに変換
-		List<CategoryConsts> categoryConsts = Arrays.asList(CategoryConsts.values());
+
+		/*		// 分類名取得を定数クラス→DB取得に変更のためコメント化
+				// 分類 Enumをリストに変換
+				List<CategoryConsts> categoryConsts = Arrays.asList(CategoryConsts.values());
+				// 分類一覧情報をセット
+				model.addAttribute("categoryConsts", categoryConsts);
+		*/
+
+		// 分類情報画面に表示するデータを取得
+		List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
 
 		// 分類一覧情報をセット
-		model.addAttribute("categoryConsts", categoryConsts);
+		model.addAttribute("categoryInfoList", categoryInfoList);
 
 		return "admin/categoryInfoControl/index";
 	}
-	
+
 	/**
 	 * 検索結果表示
 	 * 
@@ -61,9 +73,10 @@ public class CategoryInfoControlController{
 
 		// Valid項目チェック
 		if (bindingResult.hasErrors()) {
-			
+
 			// エラーメッセージをプロパティファイルから取得
-			String errorMsg = MessageManager.getMessage(messageSource, bindingResult.getGlobalError().getDefaultMessage());
+			String errorMsg = MessageManager.getMessage(messageSource,
+					bindingResult.getGlobalError().getDefaultMessage());
 			model.addAttribute("errorMsg", errorMsg);
 
 			// 分類 Enumをリストに変換
@@ -74,7 +87,6 @@ public class CategoryInfoControlController{
 
 			return "admin/categoryInfoControl/index";
 		}
-		
 
 		// 分類情報管理画面に表示するデータを取得
 		List<CategoryConsts> categoryConsts = form.getCategoryResearchResult(form.getCategory());
@@ -84,6 +96,5 @@ public class CategoryInfoControlController{
 
 		return "admin/categoryInfoControl/index";
 	}
-	
-	
+
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
@@ -1,6 +1,5 @@
 package com.digitalojt.web.controller;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.context.MessageSource;
@@ -10,13 +9,13 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
-import com.digitalojt.web.consts.CategoryConsts;
 import com.digitalojt.web.consts.UrlConsts;
 import com.digitalojt.web.entity.CategoryInfo;
 import com.digitalojt.web.form.CategoryInfoControlForm;
 import com.digitalojt.web.service.CategoryInfoService;
 import com.digitalojt.web.util.MessageManager;
 
+import jakarta.persistence.PersistenceException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -58,9 +57,9 @@ public class CategoryInfoControlController {
 			// 分類一覧情報をセット
 			model.addAttribute("categoryInfoList", categoryInfoList);
 		} catch (RuntimeException e) {
-			// エラーメッセージをセット
-			String errorMsg = "分類情報を取得できませんでした。";
-			model.addAttribute("errorMsg", errorMsg);
+			// DB情報取得エラー時のメッセージをセット
+			String dbErrorMsg = "分類情報を取得できませんでした。";
+			model.addAttribute("dbErrorMsg", dbErrorMsg);
 		}
 
 		return "admin/categoryInfoControl/index";
@@ -84,20 +83,49 @@ public class CategoryInfoControlController {
 					bindingResult.getGlobalError().getDefaultMessage());
 			model.addAttribute("errorMsg", errorMsg);
 
-			// 分類 Enumをリストに変換
-			List<CategoryConsts> categoryConsts = Arrays.asList(CategoryConsts.values());
+			/*			// 分類名取得を定数クラス→DB取得に変更のためコメント化
+						// 分類 Enumをリストに変換
+						List<CategoryConsts> categoryConsts = Arrays.asList(CategoryConsts.values());
+			
+						// 分類一覧情報をセット
+						model.addAttribute("categoryConsts", categoryConsts);
+			*/
 
-			// 分類一覧情報をセット
-			model.addAttribute("categoryConsts", categoryConsts);
+			try {
+				// 分類情報画面に表示するデータを取得
+				List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
+				// 分類一覧情報をセット
+				model.addAttribute("categoryInfoList", categoryInfoList);
+			} catch (RuntimeException e) {
+				// DB情報取得エラー時のメッセージをセット
+				String dbErrorMsg = "分類情報を取得できませんでした。";
+				model.addAttribute("dbErrorMsg", dbErrorMsg);
+			}
 
 			return "admin/categoryInfoControl/index";
 		}
 
-		// 分類情報管理画面に表示するデータを取得
-		List<CategoryConsts> categoryConsts = form.getCategoryResearchResult(form.getCategory());
+		/*		// 分類情報管理画面に表示するデータを取得
+				List<CategoryConsts> categoryConsts = form.getCategoryResearchResult(form.getCategory());
+		
+				// 分類一覧情報をセット
+				model.addAttribute("categoryConsts", categoryConsts);
+		*/
 
-		// 分類一覧情報をセット
-		model.addAttribute("categoryConsts", categoryConsts);
+		try {
+			// 分類情報管理画面に表示するデータを取得
+			List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData(form.getCategory());
+			// 分類一覧情報をセット
+			model.addAttribute("categoryInfoList", categoryInfoList);
+		} catch (NullPointerException e) {
+			// DB情報取得エラー時のメッセージをセット
+			String dbErrorMsg = "データが見つかりませんでした。";
+			model.addAttribute("dbErrorMsg", dbErrorMsg);
+		} catch (PersistenceException e) {
+			// DB情報取得エラー時のメッセージをセット
+			String dbErrorMsg = "データベース操作中にエラーが発生し、分類情報を取得できませんでした。";
+			model.addAttribute("dbErrorMsg", dbErrorMsg);
+		}
 
 		return "admin/categoryInfoControl/index";
 	}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
@@ -1,5 +1,6 @@
 package com.digitalojt.web.controller;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.context.MessageSource;
@@ -9,13 +10,13 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
+import com.digitalojt.web.consts.CategoryConsts;
 import com.digitalojt.web.consts.UrlConsts;
 import com.digitalojt.web.entity.CategoryInfo;
 import com.digitalojt.web.form.CategoryInfoControlForm;
 import com.digitalojt.web.service.CategoryInfoService;
 import com.digitalojt.web.util.MessageManager;
 
-import jakarta.persistence.PersistenceException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -57,9 +58,9 @@ public class CategoryInfoControlController {
 			// 分類一覧情報をセット
 			model.addAttribute("categoryInfoList", categoryInfoList);
 		} catch (RuntimeException e) {
-			// DB情報取得エラー時のメッセージをセット
-			String dbErrorMsg = "分類情報を取得できませんでした。";
-			model.addAttribute("dbErrorMsg", dbErrorMsg);
+			// エラーメッセージをセット
+			String errorMsg = "分類情報を取得できませんでした。";
+			model.addAttribute("errorMsg", errorMsg);
 		}
 
 		return "admin/categoryInfoControl/index";
@@ -83,49 +84,20 @@ public class CategoryInfoControlController {
 					bindingResult.getGlobalError().getDefaultMessage());
 			model.addAttribute("errorMsg", errorMsg);
 
-			/*			// 分類名取得を定数クラス→DB取得に変更のためコメント化
-						// 分類 Enumをリストに変換
-						List<CategoryConsts> categoryConsts = Arrays.asList(CategoryConsts.values());
-			
-						// 分類一覧情報をセット
-						model.addAttribute("categoryConsts", categoryConsts);
-			*/
+			// 分類 Enumをリストに変換
+			List<CategoryConsts> categoryConsts = Arrays.asList(CategoryConsts.values());
 
-			try {
-				// 分類情報画面に表示するデータを取得
-				List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
-				// 分類一覧情報をセット
-				model.addAttribute("categoryInfoList", categoryInfoList);
-			} catch (RuntimeException e) {
-				// DB情報取得エラー時のメッセージをセット
-				String dbErrorMsg = "分類情報を取得できませんでした。";
-				model.addAttribute("dbErrorMsg", dbErrorMsg);
-			}
+			// 分類一覧情報をセット
+			model.addAttribute("categoryConsts", categoryConsts);
 
 			return "admin/categoryInfoControl/index";
 		}
 
-		/*		// 分類情報管理画面に表示するデータを取得
-				List<CategoryConsts> categoryConsts = form.getCategoryResearchResult(form.getCategory());
-		
-				// 分類一覧情報をセット
-				model.addAttribute("categoryConsts", categoryConsts);
-		*/
+		// 分類情報管理画面に表示するデータを取得
+		List<CategoryConsts> categoryConsts = form.getCategoryResearchResult(form.getCategory());
 
-		try {
-			// 分類情報管理画面に表示するデータを取得
-			List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData(form.getCategory());
-			// 分類一覧情報をセット
-			model.addAttribute("categoryInfoList", categoryInfoList);
-		} catch (NullPointerException e) {
-			// DB情報取得エラー時のメッセージをセット
-			String dbErrorMsg = "データが見つかりませんでした。";
-			model.addAttribute("dbErrorMsg", dbErrorMsg);
-		} catch (PersistenceException e) {
-			// DB情報取得エラー時のメッセージをセット
-			String dbErrorMsg = "データベース操作中にエラーが発生し、分類情報を取得できませんでした。";
-			model.addAttribute("dbErrorMsg", dbErrorMsg);
-		}
+		// 分類一覧情報をセット
+		model.addAttribute("categoryConsts", categoryConsts);
 
 		return "admin/categoryInfoControl/index";
 	}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
@@ -52,12 +52,18 @@ public class CategoryInfoControlController {
 				model.addAttribute("categoryConsts", categoryConsts);
 		*/
 
-		// 分類情報画面に表示するデータを取得
-		List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
-
-		// 分類一覧情報をセット
-		model.addAttribute("categoryInfoList", categoryInfoList);
-
+		try {
+			// 分類情報画面に表示するデータを取得
+			List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
+			// 分類一覧情報をセット
+			model.addAttribute("categoryInfoList", categoryInfoList);
+		}
+		catch(RuntimeException e){
+            // エラーメッセージをセット
+         	String errorMsg = "分類情報を取得できませんでした。";
+         	model.addAttribute("errorMsg", errorMsg);
+		}
+		
 		return "admin/categoryInfoControl/index";
 	}
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
@@ -57,13 +57,12 @@ public class CategoryInfoControlController {
 			List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
 			// 分類一覧情報をセット
 			model.addAttribute("categoryInfoList", categoryInfoList);
+		} catch (RuntimeException e) {
+			// エラーメッセージをセット
+			String errorMsg = "分類情報を取得できませんでした。";
+			model.addAttribute("errorMsg", errorMsg);
 		}
-		catch(RuntimeException e){
-            // エラーメッセージをセット
-         	String errorMsg = "分類情報を取得できませんでした。";
-         	model.addAttribute("errorMsg", errorMsg);
-		}
-		
+
 		return "admin/categoryInfoControl/index";
 	}
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/CategoryInfo.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/CategoryInfo.java
@@ -1,0 +1,49 @@
+package com.digitalojt.web.entity;
+
+import java.sql.Timestamp;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 分類情報Entity
+ * 
+ * @author Okuma
+ *
+ */
+
+@Data
+@Getter
+@Setter
+@Entity
+public class CategoryInfo {
+
+	/**
+	 * 分類ID
+	 */
+	@Id
+	private int categoryId;
+
+	/**
+	 * 分類名
+	 */
+	private String categoryName;
+
+	/**
+	 * 論理削除フラグ
+	 */
+	private String deleteFlag;
+
+	/**
+	 * 更新日
+	 */
+	private Timestamp updateDate;
+
+	/**
+	 * 登録日
+	 */
+	private Timestamp createDate;
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CategoryInfoRepository.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CategoryInfoRepository.java
@@ -1,7 +1,9 @@
 package com.digitalojt.web.repository;
 
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.digitalojt.web.entity.CategoryInfo;
@@ -15,4 +17,12 @@ import com.digitalojt.web.entity.CategoryInfo;
 @Repository
 public interface CategoryInfoRepository extends JpaRepository<CategoryInfo, Integer> {
 
+	/**
+	 * 引数に合致する分類情報を取得
+	 * 
+	 * @param categoryName
+	 * @return paramで検索した結果
+	 */
+	@Query("SELECT s FROM CategoryInfo s WHERE s.categoryName = :categoryName")
+	List<CategoryInfo> findByCategoryName(String categoryName);
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CategoryInfoRepository.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CategoryInfoRepository.java
@@ -1,9 +1,7 @@
 package com.digitalojt.web.repository;
 
-import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.digitalojt.web.entity.CategoryInfo;
@@ -17,12 +15,4 @@ import com.digitalojt.web.entity.CategoryInfo;
 @Repository
 public interface CategoryInfoRepository extends JpaRepository<CategoryInfo, Integer> {
 
-	/**
-	 * 引数に合致する分類情報を取得
-	 * 
-	 * @param categoryName
-	 * @return paramで検索した結果
-	 */
-	@Query("SELECT s FROM CategoryInfo s WHERE s.categoryName = :categoryName")
-	List<CategoryInfo> findByCategoryName(String categoryName);
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CategoryInfoRepository.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CategoryInfoRepository.java
@@ -1,0 +1,18 @@
+package com.digitalojt.web.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.digitalojt.web.entity.CategoryInfo;
+
+/**
+ * 分類情報テーブルリポジトリー
+ *
+ * @author Okuma
+ * 
+ */
+@Repository
+public interface CategoryInfoRepository extends JpaRepository<CategoryInfo, Integer> {
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
@@ -1,0 +1,34 @@
+package com.digitalojt.web.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.digitalojt.web.entity.CategoryInfo;
+import com.digitalojt.web.repository.CategoryInfoRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 分類情報画面のサービスクラス
+ *
+ * @author Okuma
+ * 
+ */
+@Service
+@RequiredArgsConstructor
+public class CategoryInfoService {
+
+	/** 分類情報テーブル リポジトリー */
+	private final CategoryInfoRepository repository;
+
+	/**
+	 * 分類情報を全建検索で取得
+	 * 
+	 * @return
+	 */
+	public List<CategoryInfo> getCategoryInfoData() {
+		return repository.findAll();
+	}
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
@@ -28,7 +28,19 @@ public class CategoryInfoService {
 	 * @return
 	 */
 	public List<CategoryInfo> getCategoryInfoData() {
+
 		return repository.findAll();
+	}
+	
+	/**
+	 * 引数に合致する分類情報を取得
+	 * 
+	 * @param categoryName
+	 * @return
+	 */
+	public List<CategoryInfo> getCategoryInfoData(String categoryName) {
+
+		return repository.findByCategoryName(categoryName);
 	}
 
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
@@ -28,19 +28,7 @@ public class CategoryInfoService {
 	 * @return
 	 */
 	public List<CategoryInfo> getCategoryInfoData() {
-
 		return repository.findAll();
-	}
-	
-	/**
-	 * 引数に合致する分類情報を取得
-	 * 
-	 * @param categoryName
-	 * @return
-	 */
-	public List<CategoryInfo> getCategoryInfoData(String categoryName) {
-
-		return repository.findByCategoryName(categoryName);
 	}
 
 }

--- a/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
@@ -37,13 +37,19 @@
 			<div class="table-responsive" style="text-align: center;">
 				<table class="table table-bordered" id="dataTable">
 					<tbody>
+						<!--/* 
+						分類名取得を定数クラス→DB取得に変更のためコメント化
 						<tr th:each="item : ${categoryConsts}">
-							<td>[[${item.category}]]</td>
+						<td>[[${item.category}]]</td>
+						 */-->
+						<tr th:each="item : ${categoryInfoList}">
+							<td>[[${item.categoryName}]]</td>
 						</tr>
 					</tbody>
 				</table>
 			</div>
 		</div>
 	</div>
+
 </body>
 </html>

--- a/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
@@ -31,6 +31,10 @@
 				<div th:if="${errorMsg != null}" class="text-danger">
 					<p th:text="${errorMsg}"></p>
 				</div>
+				<!-- DB情報取得エラー時のメッセージの表示 -->
+				<div th:if="${dbErrorMsg != null}" class="text-danger">
+					<p th:text="${dbErrorMsg}"></p>
+				</div>
 			</div>
 
 			<!-- 分類情報テーブル -->

--- a/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
@@ -31,10 +31,6 @@
 				<div th:if="${errorMsg != null}" class="text-danger">
 					<p th:text="${errorMsg}"></p>
 				</div>
-				<!-- DB情報取得エラー時のメッセージの表示 -->
-				<div th:if="${dbErrorMsg != null}" class="text-danger">
-					<p th:text="${dbErrorMsg}"></p>
-				</div>
 			</div>
 
 			<!-- 分類情報テーブル -->


### PR DESCRIPTION
## 概要

分類情報管理画面の初期表示の分類情報を定数クラスからDBの分類情報テーブルから分類名を全件取得に変更

## 実装方針・詳細

- 初期表示時の定数使用部分をDBの分類情報テーブルから取得に変更
　・Controllorクラスの初期表示の定数設定部分をコメント化
　・Controllorクラスの初期表示にDBの分類情報テーブルから取得を追加
　・分類情報管理画面の表示の定数設定部分をコメント化
　・分類情報管理画面の表示にDBの分類情報テーブルから取得を追加
　・DBの分類情報テーブルから取得のため、serviceクラス・repositoryクラス・entityクラスを作成
- 初期表示時のDBの分類情報取得時の例外処理を追加
　・Controllorクラスの初期表示にDBの分類情報テーブルから取得時に例外処理を追加
　・例外が発生した場合、メッセージを表示を追加
## 影響範囲

分類情報管理画面の定数部分設定部分をDBの分類情報テーブルから取得に変更したため、分類情報管理画面の検索結果が表示されなくなっています。

## テスト

- メニュー画面の「分類情報管理」を押下
- 例外「RuntimeException」をthrowする
