### PR TITLE
add fetchCategorySearchFromTheDatabase

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ErrorMessage.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ErrorMessage.java
@@ -28,5 +28,13 @@ public class ErrorMessage {
 
 	// 分類名が空の場合のエラーメッセージ
 	public static final String CATEGORY_FIELDS_EMPTY_ERROR_MESSAGE = "category.empty";
+	
+	// DataAccessExceptionの場合のエラーメッセージ
+	public static final String DATA_ACCESS_ERROR_MESSAGE = "dataAccess.exception";
 
+	// NullPointerExceptionの場合のエラーメッセージ
+	public static final String NULL_POINTER_ERROR_MESSAGE = "nullPointer.exception";
+	
+	// Exceptionの場合のエラーメッセージ
+	public static final String ALL_ERROR_MESSAGE = "all.exception";
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
@@ -1,6 +1,5 @@
 package com.digitalojt.web.controller;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.context.MessageSource;
@@ -10,13 +9,13 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
-import com.digitalojt.web.consts.CategoryConsts;
 import com.digitalojt.web.consts.UrlConsts;
 import com.digitalojt.web.entity.CategoryInfo;
 import com.digitalojt.web.form.CategoryInfoControlForm;
 import com.digitalojt.web.service.CategoryInfoService;
 import com.digitalojt.web.util.MessageManager;
 
+import jakarta.persistence.PersistenceException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -58,9 +57,9 @@ public class CategoryInfoControlController {
 			// 分類一覧情報をセット
 			model.addAttribute("categoryInfoList", categoryInfoList);
 		} catch (RuntimeException e) {
-			// エラーメッセージをセット
-			String errorMsg = "分類情報を取得できませんでした。";
-			model.addAttribute("errorMsg", errorMsg);
+			// DB情報取得エラー時のメッセージをセット
+			String dbErrorMsg = "分類情報を取得できませんでした。";
+			model.addAttribute("dbErrorMsg", dbErrorMsg);
 		}
 
 		return "admin/categoryInfoControl/index";
@@ -84,20 +83,49 @@ public class CategoryInfoControlController {
 					bindingResult.getGlobalError().getDefaultMessage());
 			model.addAttribute("errorMsg", errorMsg);
 
-			// 分類 Enumをリストに変換
-			List<CategoryConsts> categoryConsts = Arrays.asList(CategoryConsts.values());
+			/*			// 分類名取得を定数クラス→DB取得に変更のためコメント化
+						// 分類 Enumをリストに変換
+						List<CategoryConsts> categoryConsts = Arrays.asList(CategoryConsts.values());
+			
+						// 分類一覧情報をセット
+						model.addAttribute("categoryConsts", categoryConsts);
+			*/
 
-			// 分類一覧情報をセット
-			model.addAttribute("categoryConsts", categoryConsts);
+			try {
+				// 分類情報画面に表示するデータを取得
+				List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
+				// 分類一覧情報をセット
+				model.addAttribute("categoryInfoList", categoryInfoList);
+			} catch (RuntimeException e) {
+				// DB情報取得エラー時のメッセージをセット
+				String dbErrorMsg = "分類情報を取得できませんでした。";
+				model.addAttribute("dbErrorMsg", dbErrorMsg);
+			}
 
 			return "admin/categoryInfoControl/index";
 		}
 
-		// 分類情報管理画面に表示するデータを取得
-		List<CategoryConsts> categoryConsts = form.getCategoryResearchResult(form.getCategory());
+		/*		// 分類情報管理画面に表示するデータを取得
+				List<CategoryConsts> categoryConsts = form.getCategoryResearchResult(form.getCategory());
+		
+				// 分類一覧情報をセット
+				model.addAttribute("categoryConsts", categoryConsts);
+		*/
 
-		// 分類一覧情報をセット
-		model.addAttribute("categoryConsts", categoryConsts);
+		try {
+			// 分類情報管理画面に表示するデータを取得
+			List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData(form.getCategory());
+			// 分類一覧情報をセット
+			model.addAttribute("categoryInfoList", categoryInfoList);
+		} catch (NullPointerException e) {
+			// DB情報取得エラー時のメッセージをセット
+			String dbErrorMsg = "データが見つかりませんでした。";
+			model.addAttribute("dbErrorMsg", dbErrorMsg);
+		} catch (PersistenceException e) {
+			// DB情報取得エラー時のメッセージをセット
+			String dbErrorMsg = "データベース操作中にエラーが発生し、分類情報を取得できませんでした。";
+			model.addAttribute("dbErrorMsg", dbErrorMsg);
+		}
 
 		return "admin/categoryInfoControl/index";
 	}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategoryInfoControlController.java
@@ -3,19 +3,20 @@ package com.digitalojt.web.controller;
 import java.util.List;
 
 import org.springframework.context.MessageSource;
+import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
+import com.digitalojt.web.consts.ErrorMessage;
 import com.digitalojt.web.consts.UrlConsts;
 import com.digitalojt.web.entity.CategoryInfo;
 import com.digitalojt.web.form.CategoryInfoControlForm;
 import com.digitalojt.web.service.CategoryInfoService;
 import com.digitalojt.web.util.MessageManager;
 
-import jakarta.persistence.PersistenceException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -52,13 +53,25 @@ public class CategoryInfoControlController {
 		*/
 
 		try {
-			// 分類情報画面に表示するデータを取得
-			List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
-			// 分類一覧情報をセット
-			model.addAttribute("categoryInfoList", categoryInfoList);
-		} catch (RuntimeException e) {
+			/*			// 全分類情報を取得処理を独立させるためコメント化
+						// 分類情報画面に表示するデータを取得
+						List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
+						// 分類一覧情報をセット
+						model.addAttribute("categoryInfoList", categoryInfoList);
+			*/
+			//tryCatchテスト用
+			//testDataAccessException();
+			//全分類情報を取得
+			getCategoryInfoList(model);
+			
+		} catch (DataAccessException e) {
+			/*			//メッセージ・プロパティにまとめるためコメント化
+						// DB情報取得エラー時のメッセージをセット
+						String dbErrorMsg = "データベース操作中にエラーが発生しました。管理者へ問い合わせください。";
+			*/
+			// エラーメッセージをプロパティファイルから取得
+			String dbErrorMsg = MessageManager.getMessage(messageSource,ErrorMessage.DATA_ACCESS_ERROR_MESSAGE);
 			// DB情報取得エラー時のメッセージをセット
-			String dbErrorMsg = "分類情報を取得できませんでした。";
 			model.addAttribute("dbErrorMsg", dbErrorMsg);
 		}
 
@@ -92,13 +105,26 @@ public class CategoryInfoControlController {
 			*/
 
 			try {
-				// 分類情報画面に表示するデータを取得
-				List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
-				// 分類一覧情報をセット
-				model.addAttribute("categoryInfoList", categoryInfoList);
-			} catch (RuntimeException e) {
+				/*				// 全分類情報を取得処理を独立させるためコメント化
+								// 分類情報画面に表示するデータを取得
+								List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
+								// 分類一覧情報をセット
+								model.addAttribute("categoryInfoList", categoryInfoList);
+				*/	
+				//tryCatchテスト用
+				//testDataAccessException();
+				//全分類情報を取得
+				getCategoryInfoList(model);
+				
+				
+			} catch (DataAccessException e) {
+				/*				//メッセージ・プロパティにまとめるためコメント化
+								// DB情報取得エラー時のメッセージをセット
+								String dbErrorMsg = "データベース操作中にエラーが発生しました。管理者へ問い合わせください。";
+				*/				
+				// エラーメッセージをプロパティファイルから取得
+				String dbErrorMsg = MessageManager.getMessage(messageSource,ErrorMessage.DATA_ACCESS_ERROR_MESSAGE);
 				// DB情報取得エラー時のメッセージをセット
-				String dbErrorMsg = "分類情報を取得できませんでした。";
 				model.addAttribute("dbErrorMsg", dbErrorMsg);
 			}
 
@@ -118,16 +144,54 @@ public class CategoryInfoControlController {
 			// 分類一覧情報をセット
 			model.addAttribute("categoryInfoList", categoryInfoList);
 		} catch (NullPointerException e) {
+			/*			//メッセージ・プロパティにまとめるためコメント化
+						// DB情報取得エラー時のメッセージをセット
+						String dbErrorMsg = "予期せぬエラーが発生しました。管理者へ問い合わせください。(エラーコード：2)";
+			*/
+			// エラーメッセージをプロパティファイルから取得
+			String dbErrorMsg = MessageManager.getMessage(messageSource,ErrorMessage.NULL_POINTER_ERROR_MESSAGE);
 			// DB情報取得エラー時のメッセージをセット
-			String dbErrorMsg = "データが見つかりませんでした。";
 			model.addAttribute("dbErrorMsg", dbErrorMsg);
-		} catch (PersistenceException e) {
+		} catch (DataAccessException e) {
+			/*			//メッセージ・プロパティにまとめるためコメント化
+						// DB情報取得エラー時のメッセージをセット
+						String dbErrorMsg = "データベース操作中にエラーが発生しました。管理者へ問い合わせください。";
+			*/
+			// エラーメッセージをプロパティファイルから取得
+			String dbErrorMsg = MessageManager.getMessage(messageSource,ErrorMessage.DATA_ACCESS_ERROR_MESSAGE);
 			// DB情報取得エラー時のメッセージをセット
-			String dbErrorMsg = "データベース操作中にエラーが発生し、分類情報を取得できませんでした。";
+			model.addAttribute("dbErrorMsg", dbErrorMsg);
+		} catch (Exception e) {
+			/*			//メッセージ・プロパティにまとめるためコメント化
+						// DB情報取得エラー時のメッセージをセット
+						String dbErrorMsg = "予期せぬエラーが発生しました。管理者へ問い合わせください。(エラーコード：1)";
+			*/
+			// エラーメッセージをプロパティファイルから取得
+			String dbErrorMsg = MessageManager.getMessage(messageSource,ErrorMessage.ALL_ERROR_MESSAGE);
+			// DB情報取得エラー時のメッセージをセット
 			model.addAttribute("dbErrorMsg", dbErrorMsg);
 		}
 
 		return "admin/categoryInfoControl/index";
 	}
+	
+	/**
+	 * 全分類情報を取得
+	 * 
+	 * @param model
+	 * @param form
+	 */
+	public void getCategoryInfoList(Model model) {
+		// 分類情報画面に表示するデータを取得
+		List<CategoryInfo> categoryInfoList = categoryInfoService.getCategoryInfoData();
+		// 分類一覧情報をセット
+		model.addAttribute("categoryInfoList", categoryInfoList);
+	}
+	
+	public void testDataAccessException() throws DataAccessException {
+		// データベース操作 
+		throw new DataAccessException("データベース操作中にエラーが発生しました") {}; 
+	}
+	
 
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CategoryInfoRepository.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CategoryInfoRepository.java
@@ -1,7 +1,9 @@
 package com.digitalojt.web.repository;
 
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.digitalojt.web.entity.CategoryInfo;
@@ -15,4 +17,12 @@ import com.digitalojt.web.entity.CategoryInfo;
 @Repository
 public interface CategoryInfoRepository extends JpaRepository<CategoryInfo, Integer> {
 
+	/**
+	 * 引数に合致する分類情報を取得
+	 * 
+	 * @param categoryName
+	 * @return paramで検索した結果
+	 */
+	@Query("SELECT s FROM CategoryInfo s WHERE s.categoryName = :categoryName")
+	List<CategoryInfo> findByCategoryName(String categoryName);
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategoryInfoService.java
@@ -28,7 +28,19 @@ public class CategoryInfoService {
 	 * @return
 	 */
 	public List<CategoryInfo> getCategoryInfoData() {
+
 		return repository.findAll();
+	}
+	
+	/**
+	 * 引数に合致する分類情報を取得
+	 * 
+	 * @param categoryName
+	 * @return
+	 */
+	public List<CategoryInfo> getCategoryInfoData(String categoryName) {
+
+		return repository.findByCategoryName(categoryName);
 	}
 
 }

--- a/DroneInventorySystem/src/main/resources/messages.properties
+++ b/DroneInventorySystem/src/main/resources/messages.properties
@@ -2,6 +2,9 @@
 allField.empty=すべてのフィールドが空です。少なくとも1つのフィールドに値を入力してください。
 unexpected.input=予期せぬ入力を検知しました。
 invalid.input=不正な文字列を検出しました。
+all.exception=予期せぬエラーが発生しました。管理者へ問い合わせください。（エラーコード：1）
+dataAccess.exception=データベース操作中にエラーが発生しました。管理者へ問い合わせください。
+nullPointer.exception=予期せぬエラーが発生しました。管理者へ問い合わせください。（エラーコード：2）
 
 # ログイン画面
 login.wrongInput=管理者IDとパスワードの組み合わせが間違っています。

--- a/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categoryInfoControl/index.html
@@ -31,6 +31,10 @@
 				<div th:if="${errorMsg != null}" class="text-danger">
 					<p th:text="${errorMsg}"></p>
 				</div>
+				<!-- DB情報取得エラー時のメッセージの表示 -->
+				<div th:if="${dbErrorMsg != null}" class="text-danger">
+					<p th:text="${dbErrorMsg}"></p>
+				</div>
 			</div>
 
 			<!-- 分類情報テーブル -->


### PR DESCRIPTION
## 概要

分類情報管理画面の分類情報検索結果を定数クラスからDBの分類情報テーブルから取得に変更

## 実装方針・詳細

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 分類情報検索時の定数使用部分をDBの分類情報テーブルから取得に変更
　・Controllorクラスの分類情報検索時の定数設定部分をコメント化
　・Controllorクラスの分類情報検索時にDBの分類情報テーブルから取得を追加
- 分類情報検索時のDBの例外処理を追加
　・Controllorクラスの分類情報検索時にDBの分類情報テーブルから取得時に例外処理を追加
　・例外が発生した場合のメッセージを表示位置を変更

## 影響範囲

特に影響なし

## テスト

このセクションでは、この PR に関連するテストケースやテスト方法を記載してください。

- 分類情報管理画面で分類名を検索
- 例外「NullPointerException」をthrowする
- 例外「PersistenceException」をthrowする
