### PR TITLE
add CenterInfo_Update_Window

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ErrorMessage.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ErrorMessage.java
@@ -62,6 +62,9 @@ public class ErrorMessage {
 	// 文字超過に関するエラーメッセージ（備考）
 	public static final String NOTES_LENGTH_ERROR_MESSAGE = "notes.length.wrongInput";
 
+	// センターIDに紐づくデータが空の場合のエラーメッセージ
+	public static final String NULL_CENTER_ID_MESSAGE = "null.centerId";
+
 	// DataAccessExceptionの場合のエラーメッセージ
 	public static final String DATA_ACCESS_ERROR_MESSAGE = "dataAccess.exception";
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ParamsLimits.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ParamsLimits.java
@@ -48,6 +48,9 @@ public class ParamsLimits {
 	//備考の最大文字数
 	public static final int NOTES_MAX_LENGTH = 100;
 
+	//センターIDの数値
+	public static final String CENTER_ID_NUMERIC = "/^[0-9]+$/";
+
 	// 郵便番号のフォーマット
 	public static final String POST_CODE_FORMAT = "^[0-9]{3}-[0-9]{4}$";
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ResultMessage.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/ResultMessage.java
@@ -14,4 +14,10 @@ public class ResultMessage {
 	// 新規登録エラーのメッセージ
 	public static final String REGISTRATION_ERROR = "registration.error";
 
+	// 更新完了のメッセージ
+	public static final String UPDATE_COMPLETED = "update.completed";
+
+	// 更新エラーのメッセージ
+	public static final String UPDATE_ERROR = "update.error";
+
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
@@ -45,6 +45,12 @@ public class UrlConsts {
 	// 在庫センター情報画面 登録完了
 	public static final String CENTER_INFO_REGISTRATION_COMPLETED = "/admin/centerInfo/registrationCompleted";
 
+	// 在庫センター情報画面 更新/削除画面　表示
+	public static final String CENTER_INFO_DETAILS = "/admin/centerInfo/details/{centerId}";
+
+	// 在庫センター情報画面 更新/削除画面
+	public static final String CENTER_INFO_UPDATE = "/admin/centerInfo/update";
+
 	// 認証不要画面
 	public static final String[] NO_AUTHENTICATION = { LOGIN, AUTHENTICATE };
 

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CenterInfoController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CenterInfoController.java
@@ -9,15 +9,18 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import com.digitalojt.web.consts.ErrorMessage;
 import com.digitalojt.web.consts.Region;
 import com.digitalojt.web.consts.ResultMessage;
 import com.digitalojt.web.consts.UrlConsts;
 import com.digitalojt.web.entity.CenterInfo;
 import com.digitalojt.web.form.CenterInfoForm;
 import com.digitalojt.web.form.RegisterCenterInfoForm;
+import com.digitalojt.web.form.UpdateCenterInfoForm;
 import com.digitalojt.web.service.CenterInfoService;
 import com.digitalojt.web.util.MessageManager;
 
@@ -162,4 +165,80 @@ public class CenterInfoController {
 		// 初期表示にリダイレクト
 		return "redirect:" + UrlConsts.CENTER_INFO;
 	}
+
+	/**
+	 * センター情報詳細（更新/削除）画面表示
+	 * 
+	 * @param centerId
+	 * @param model
+	 * @param redirectAttributes
+	 * @return
+	 */
+	@GetMapping(UrlConsts.CENTER_INFO_DETAILS)
+	public String details(@PathVariable int centerId, Model model, RedirectAttributes redirectAttributes) {
+
+		// 在庫センター情報詳細（更新/削除）画面に表示するデータを取得
+		List<CenterInfo> centerInfoList = centerInfoService.getCenterInfoData(centerId);
+
+		if (!centerInfoList.isEmpty()) {
+			// 在庫センター情報詳細をセット
+			model.addAttribute("centerInfoList", centerInfoList);
+
+			return UrlConsts.CENTER_INFO_UPDATE;
+		} else {
+			// エラーメッセージをプロパティファイルから取得
+			String errorMsg = messageSource.getMessage(ErrorMessage.NULL_CENTER_ID_MESSAGE, null,
+					Locale.getDefault());
+			redirectAttributes.addFlashAttribute("errorMsg", errorMsg);
+
+			// 初期表示にリダイレクト
+			return "redirect:" + UrlConsts.CENTER_INFO;
+		}
+	}
+
+	/**
+	 * 更新結果を表示
+	 * 
+	 * @param form
+	 * @param bindingResult
+	 * @param redirectAttributes
+	 * @return
+	 */
+	@PostMapping(UrlConsts.CENTER_INFO_UPDATE)
+	public String update(@Valid UpdateCenterInfoForm form, BindingResult bindingResult,
+			RedirectAttributes redirectAttributes) {
+
+		// Valid項目チェック
+		if (bindingResult.hasErrors()) {
+
+			// エラーメッセージをプロパティファイルから取得しフラッシュ属性として設定	
+			String errorMsg = MessageManager.getMessage(messageSource,
+					bindingResult.getGlobalError().getDefaultMessage());
+			redirectAttributes.addFlashAttribute("errorMsg", errorMsg);
+
+			return "redirect:/admin/centerInfo/details/" + form.getCenterId();
+		}
+
+		// 在庫センター情報を登録
+		try {
+			centerInfoService.updateCenterInfo(form);
+		} catch (Exception e) {
+			// エラーメッセージをフラッシュ属性として設定
+			String errorMsg = messageSource.getMessage(ResultMessage.UPDATE_ERROR, null,
+					Locale.getDefault());
+			redirectAttributes.addFlashAttribute("errorMsg", errorMsg);
+
+			// 初期表示にリダイレクト
+			return "redirect:" + UrlConsts.CENTER_INFO;
+		}
+
+		// 登録完了メッセージをフラッシュ属性として設定
+		String completedMsg = messageSource.getMessage(ResultMessage.UPDATE_COMPLETED, null,
+				Locale.getDefault());
+		redirectAttributes.addFlashAttribute("completedMsg", completedMsg);
+
+		// 初期表示にリダイレクト
+		return "redirect:" + UrlConsts.CENTER_INFO;
+	}
+
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/CenterInfo.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/CenterInfo.java
@@ -2,6 +2,7 @@ package com.digitalojt.web.entity;
 
 import java.sql.Timestamp;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -30,54 +31,52 @@ public class CenterInfo {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Id
 	private int centerId;
-	
+
 	/**
 	 * センター名
 	 */
 	private String centerName;
-	
+
 	/**
 	 * 郵便番号
 	 */
 	private String postCode;
 
-	
 	/**
 	 * 住所
 	 */
 	private String address;
-	
+
 	/**
 	 * 電話番号
 	 */
 	private String phoneNumber;
-	
+
 	/**
 	 * 管理者名
 	 */
 	private String managerName;
-	
+
 	/**
 	 * 未使用フラグ
 	 */
 	private int operationalStatus;
-	
+
 	/**
 	 * 最大容量
 	 */
 	private String maxStorageCapacity;
-	
+
 	/**
 	 * 現在容量
 	 */
 	private String currentStorageCapacity;
-	
+
 	/**
 	 *　備考
 	 */
 	private String notes;
 
-	
 	/**
 	 * 論理削除フラグ
 	 */
@@ -91,29 +90,28 @@ public class CenterInfo {
 	/**
 	 * 登録日
 	 */
+	@Column(updatable = false)
 	private Timestamp createDate;
-	
-
 
 	/**
 	 * 新規登録時に呼び出されるメソッド
-     * エンティティの作成日時および更新日時を設定し、
-     * 削除フラグのデフォルト値を設定
+	 * エンティティの作成日時および更新日時を設定し、
+	 * 削除フラグのデフォルト値を設定
 	 */
-    @PrePersist
-    protected void onCreate() {
-        Timestamp now = new Timestamp(System.currentTimeMillis());
-        createDate = now;
-        updateDate = now;
-        deleteFlag = "0"; // デフォルト値を設定
-    }
+	@PrePersist
+	protected void onCreate() {
+		Timestamp now = new Timestamp(System.currentTimeMillis());
+		createDate = now;
+		updateDate = now;
+		deleteFlag = "0"; // デフォルト値を設定
+	}
 
-    /**
-     * 更新時に呼び出されるメソッド
-     * エンティティの更新日時を現在の日時に設定
-     */
-    @PreUpdate
-    protected void onUpdate() {
-        updateDate = new Timestamp(System.currentTimeMillis());
-    }
+	/**
+	 * 更新時に呼び出されるメソッド
+	 * エンティティの更新日時を現在の日時に設定
+	 */
+	@PreUpdate
+	protected void onUpdate() {
+		updateDate = new Timestamp(System.currentTimeMillis());
+	}
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/form/UpdateCenterInfoForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/form/UpdateCenterInfoForm.java
@@ -1,0 +1,71 @@
+package com.digitalojt.web.form;
+
+import com.digitalojt.web.validation.UpdateCenterInfoFormValidator;
+
+import lombok.Data;
+
+/**
+ * 在庫センター情報詳細（更新/削除）画面のフォームクラス
+ * 
+ * @author Okuma
+ *
+ */
+@Data
+@UpdateCenterInfoFormValidator
+public class UpdateCenterInfoForm {
+	/**
+	 * センターID
+	 */
+	private int centerId;
+
+	/**
+	 * センター名
+	 */
+	private String centerName;
+
+	/**
+	 * 郵便番号
+	 */
+	private String postCode;
+
+	/**
+	 * 住所
+	 */
+	private String address;
+
+	/**
+	 * 電話番号
+	 */
+	private String phoneNumber;
+
+	/**
+	 * 管理者名
+	 */
+	private String managerName;
+
+	/**
+	 * 稼働状況ステータス
+	 */
+	private int operationalStatus;
+
+	/**
+	 * 最大保管容量（m³）
+	 */
+	private String maxStorageCapacity;
+
+	/**
+	 * 現在保管容量（m³）
+	 */
+	private String currentStorageCapacity;
+
+	/**
+	 * 備考
+	 */
+	private String notes;
+
+	/**
+	 * 論理削除フラグ
+	 */
+	private String deleteFlag;
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CenterInfoRepository.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CenterInfoRepository.java
@@ -31,4 +31,13 @@ public interface CenterInfoRepository extends JpaRepository<CenterInfo, Integer>
 	List<CenterInfo> findByCenterNameAndRegionAndStorageCapacity(
 			String centerName,
 			String region);
+
+	/**
+	 * センターIDに合致する在庫センター情報を取得
+	 * 
+	 * @param centerId
+	 * @return paramで検索した結果
+	 */
+
+	List<CenterInfo> findByCenterId(int centerId);
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CenterInfoService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CenterInfoService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.digitalojt.web.entity.CenterInfo;
 import com.digitalojt.web.form.RegisterCenterInfoForm;
+import com.digitalojt.web.form.UpdateCenterInfoForm;
 import com.digitalojt.web.repository.CenterInfoRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -55,6 +56,40 @@ public class CenterInfoService {
 	public void registerCenterInfo(RegisterCenterInfoForm form) {
 		// 在庫センター情報を登録するためのCenterInfoオブジェクトを作成
 		CenterInfo centerInfo = new CenterInfo();
+		centerInfo.setCenterName(form.getCenterName());
+		centerInfo.setPostCode(form.getPostCode());
+		centerInfo.setAddress(form.getAddress());
+		centerInfo.setPhoneNumber(form.getPhoneNumber());
+		centerInfo.setManagerName(form.getManagerName());
+		centerInfo.setOperationalStatus(form.getOperationalStatus());
+		centerInfo.setMaxStorageCapacity(form.getMaxStorageCapacity());
+		centerInfo.setCurrentStorageCapacity(form.getCurrentStorageCapacity());
+		centerInfo.setNotes(form.getNotes());
+
+		repository.save(centerInfo);
+	}
+
+	/**
+	 * センターIDに合致する在庫センター情報を取得
+	 * 
+	 * @param centerId
+	 * @return
+	 */
+	public List<CenterInfo> getCenterInfoData(int centerId) {
+		return repository.findByCenterId(centerId);
+	}
+
+	/**
+	 * センターIDに合致する在庫センター情報を更新
+	 * 
+	 * @param form
+	 */
+	@Transactional(rollbackForClassName = { "Exception" })
+	public void updateCenterInfo(UpdateCenterInfoForm form) {
+		// 在庫センター情報を更新するためのCenterInfoオブジェクトを作成
+		CenterInfo centerInfo = new CenterInfo();
+		centerInfo.setCenterId(form.getCenterId());
+		centerInfo.setDeleteFlag(form.getDeleteFlag());
 		centerInfo.setCenterName(form.getCenterName());
 		centerInfo.setPostCode(form.getPostCode());
 		centerInfo.setAddress(form.getAddress());

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/UpdateCenterInfoFormValidator.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/UpdateCenterInfoFormValidator.java
@@ -1,0 +1,28 @@
+package com.digitalojt.web.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.digitalojt.web.consts.ErrorMessage;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+/**
+ * 在庫センター情報詳細（更新/削除）画面のバリデーションチェック インターフェース
+ * 
+ * @author Okuma
+ */
+@Constraint(validatedBy = UpdateCenterInfoFormValidatorImpl.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UpdateCenterInfoFormValidator {
+
+	String message() default ErrorMessage.ALL_FIELDS_EMPTY_ERROR_MESSAGE;
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/UpdateCenterInfoFormValidatorImpl.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/validation/UpdateCenterInfoFormValidatorImpl.java
@@ -1,0 +1,135 @@
+package com.digitalojt.web.validation;
+
+import com.digitalojt.web.consts.ErrorMessage;
+import com.digitalojt.web.consts.OperationalStatus;
+import com.digitalojt.web.consts.ParamsLimits;
+import com.digitalojt.web.form.UpdateCenterInfoForm;
+import com.digitalojt.web.util.ParmCheckUtil;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * 在庫センター情報詳細（更新/削除）画面のバリデーションチェック 実装クラス
+ * 
+ * @author Okuma
+ */
+public class UpdateCenterInfoFormValidatorImpl
+		implements ConstraintValidator<UpdateCenterInfoFormValidator, UpdateCenterInfoForm> {
+
+	/**
+	 * バリデーションチェック
+	 */
+	@Override
+	public boolean isValid(UpdateCenterInfoForm form, ConstraintValidatorContext context) {
+
+		// すべてのフィールドが空かをチェック　　→不要　画面の機能で必須項目の入力をチェックしているため
+
+		// センター名のチェック
+		// 不正文字列チェック
+		if (ParmCheckUtil.isParameterInvalid(form.getCenterName())) {
+			setErrorMessage(context, ErrorMessage.INVALID_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 文字数チェック
+		if (form.getCenterName().length() > ParamsLimits.CENTER_INFO_MAX_LENGTH) {
+			setErrorMessage(context, ErrorMessage.CENTER_NAME_LENGTH_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 郵便番号のチェック
+		// 正規表現によるフォーマットチェック
+		if (!form.getPostCode().matches(ParamsLimits.POST_CODE_FORMAT)) {
+			setErrorMessage(context, ErrorMessage.INVALID_POST_CODE_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 住所のチェック
+		// 不正文字列チェック
+		if (ParmCheckUtil.isParameterInvalid(form.getAddress())) {
+			setErrorMessage(context, ErrorMessage.INVALID_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 文字数チェック
+		if (form.getAddress().length() > ParamsLimits.ADDRESS_MAX_LENGTH) {
+			setErrorMessage(context, ErrorMessage.ADDRESS_LENGTH_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 電話番号のチェック
+		// 正規表現によるフォーマットチェック
+
+		if (!form.getPhoneNumber().matches(ParamsLimits.PHONE_NUMBER_FORMAT)) {
+			setErrorMessage(context, ErrorMessage.INVALID_PHONE_NUMBER_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 管理者名のチェック
+		// 不正文字列チェック
+		if (ParmCheckUtil.isParameterInvalid(form.getManagerName())) {
+			setErrorMessage(context, ErrorMessage.INVALID_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 文字数チェック
+		if (form.getManagerName().length() > ParamsLimits.MANAGER_NAME_MAX_LENGTH) {
+			setErrorMessage(context, ErrorMessage.MANAGER_NAME_LENGTH_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 稼働状況ステータスのチェック
+		if (form.getOperationalStatus() != OperationalStatus.ACTIVE.getType() &&
+				form.getOperationalStatus() != OperationalStatus.INACTIVE.getType()) {
+			setErrorMessage(context, ErrorMessage.UNEXPECTED_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 最大保管容量（m³）のチェック
+		if (Integer.parseInt(form.getMaxStorageCapacity()) < ParamsLimits.MIN_STORAGE_CAPACITY
+				|| Integer.parseInt(form.getMaxStorageCapacity()) > ParamsLimits.MAX_STORAGE_CAPACITY) {
+			setErrorMessage(context, ErrorMessage.INVALID_MAX_STORAGE_CAPACITY_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 現在保管容量（m³）のチェック
+		if (Integer.parseInt(form.getCurrentStorageCapacity()) < ParamsLimits.MIN__CURRENT_STORAGE_CAPACITY) {
+			setErrorMessage(context, ErrorMessage.INVALID_CURRENT_STORAGE_CAPACITY_ERROR_MESSAGE);
+			return false;
+		} else if (Integer.parseInt(form.getCurrentStorageCapacity()) > Integer
+				.parseInt(form.getMaxStorageCapacity())) {
+			setErrorMessage(context, ErrorMessage.INVALID_CURRENT_STORAGE_CAPACITY_OVER_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 備考のチェック
+		// 不正文字列チェック
+		if (ParmCheckUtil.isParameterInvalid(form.getNotes())) {
+			setErrorMessage(context, ErrorMessage.INVALID_INPUT_ERROR_MESSAGE);
+			return false;
+		}
+
+		// 文字数チェック
+		if (form.getNotes().length() > ParamsLimits.NOTES_MAX_LENGTH) {
+			setErrorMessage(context, ErrorMessage.NOTES_LENGTH_ERROR_MESSAGE);
+			return false;
+		}
+
+		// その他のバリデーションに問題なければtrueを返す
+		return true;
+	}
+
+	/**	
+	 * エラーメッセージを設定
+	 * 
+	 * @param context
+	 * @param errorMessage
+	 * 
+	 */
+	private void setErrorMessage(ConstraintValidatorContext context, String errorMessage) {
+		context.disableDefaultConstraintViolation();
+		context.buildConstraintViolationWithTemplate(errorMessage)
+				.addConstraintViolation();
+	}
+}

--- a/DroneInventorySystem/src/main/resources/messages.properties
+++ b/DroneInventorySystem/src/main/resources/messages.properties
@@ -13,6 +13,9 @@ login.wrongInput=管理者IDとパスワードの組み合わせが間違って�
 centerName.length.wrongInput=センター名は20文字以内で入力してください。
 registration.completed=在庫センター情報の新規登録が完了しました。
 registration.error=予期せぬエラーを検知しました。システム管理者へ問い合わせください。(エラーコード：3）
+update.completed=在庫センター情報の更新が完了しました。
+update.error=予期せぬエラーを検知しました。システム管理者へ問い合わせください。(エラーコード：5）
+null.centerId=予期せぬエラーを検知しました。システム管理者へ問い合わせください。(エラーコード：4）
 
 # 在庫センター情報　登録画面
 invalid.postCode.Input=郵便番号は「000-0000」で入力してください。

--- a/DroneInventorySystem/src/main/resources/templates/admin/centerInfo/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/centerInfo/index.html
@@ -58,7 +58,8 @@
 					</thead>
 					<tbody>
 						<tr th:each="item : ${centerInfoList}">
-							<td>[[${item.centerName}]]</td>
+							<td><a
+								th:href="@{/admin/centerInfo/details/{centerId}(centerId=${item.centerId})}">[[${item.centerName}]]</a></td>
 							<td>[[${item.address}]]</td>
 							<td>[[${item.phoneNumber}]]</td>
 							<td>[[${item.managerName}]]</td>

--- a/DroneInventorySystem/src/main/resources/templates/admin/centerInfo/update.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/centerInfo/update.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+	th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}">
+<head>
+<title>InvenTrack - 更新</title>
+</head>
+
+<body>
+	<div class="card shadow mb-4">
+
+		<div class="card-header py-3">
+			<h6 class="m-0 font-weight-bold text-primary">在庫センター情報 更新/削除</h6>
+		</div>
+
+		<!-- 更新フォーム -->
+
+		<div class="d-flex justify-content-center align-items-center">
+			<div class="card shadow-lg" style="width: 70%; max-width: 800px">
+				<div class="card-body py-2">
+					<form class="small" method="post"
+						th:action="@{'/admin/centerInfo/update'}"
+						th:each="center : ${centerInfoList}">
+
+						<!-- 在庫センターID -->
+						<input type="hidden" class="form-control form-control-sm"
+							id="centerId" name="centerId" th:value="${center.centerId}" />
+						<!-- 作成日 -->
+						<input type="hidden" class="form-control form-control-sm"
+							id="deleteFlag" name="deleteFlag" th:value="${center.deleteFlag}" />
+
+						<div class="mb-2" id="custum-form">
+							<label for="centerName" class="form-label"><span
+								class="text-danger">*</span> 必須項目</label>
+							<!-- エラーメッセージの表示 -->
+							<div th:if="${errorMsg != null}" class="text-danger">
+								<p th:text="${errorMsg}"></p>
+							</div>
+						</div>
+
+						<!-- 在庫センター名 -->
+						<div class="mb-2" id="custum-form">
+							<label for="centerName" class="form-label">在庫センター名<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="centerName"
+								name="centerName" placeholder="○○物流センター"
+								th:value="${center.centerName}" required />
+						</div>
+
+						<!-- 郵便番号 -->
+						<div class="mb-2" id="custum-form">
+							<label for="postCode" class="form-label">郵便番号<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="postCode"
+								name="postCode" placeholder="000-0000"
+								th:value="${center.postCode}" required />
+						</div>
+
+						<!-- 住所 -->
+						<div class="mb-2" id="custum-form">
+							<label for="address" class="form-label">住所<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="address" name="address"
+								placeholder="〇県〇市" th:value="${center.address}" required />
+						</div>
+
+						<!-- 電話番号 -->
+						<div class="mb-2" id="custum-form">
+							<label for="phoneNumber" class="form-label">電話番号<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="phoneNumber"
+								name="phoneNumber" placeholder="000-0000-0000"
+								th:value="${center.phoneNumber}" required />
+						</div>
+
+						<!-- 管理者名 -->
+						<div class="mb-2" id="custum-form">
+							<label for="managerName" class="form-label">管理者名<span
+								class="text-danger">*</span></label> <input type="text"
+								class="form-control form-control-sm" id="managerName"
+								name="managerName" placeholder="田中太郎"
+								th:value="${center.managerName}" required />
+						</div>
+
+						<!-- 稼働状況ステータス -->
+						<div class="mb-2" id="custum-form">
+							<label class="form-label">稼働状況ステータス<span
+								class="text-danger">*</span></label>
+							<div class="form-check form-check-inline">
+								<input class="form-check-input" type="radio" value="0"
+									id="operationalStatusActive" name="operationalStatus" required
+									th:attr="checked=${center.operationalStatus == 0}" /> <label
+									class="form-check-label" for="operationalStatusActive">稼働中</label>
+							</div>
+							<div class="form-check form-check-inline">
+								<input class="form-check-input" type="radio" value="1"
+									id="operationalStatusInactive" name="operationalStatus"
+									required th:attr="checked=${center.operationalStatus == 1}" />
+								<label class="form-check-label" for="operationalStatusInactive">稼働停止</label>
+							</div>
+						</div>
+
+						<!-- 最大保管容量 -->
+						<div class="mb-2" id="custum-form">
+							<label for="maxStorageCapacity" class="form-label">最大保管容量（m³）<span
+								class="text-danger">*</span></label> <input type="number"
+								class="form-control form-control-sm" id="maxStorageCapacity"
+								name="maxStorageCapacity" placeholder="500"
+								th:value="${center.maxStorageCapacity}" required />
+						</div>
+
+						<!-- 現在保管容量 -->
+						<div class="mb-2" id="custum-form">
+							<label for="currentStorageCapacity" class="form-label">現在保管容量（m³）<span
+								class="text-danger">*</span></label> <input type="number"
+								class="form-control form-control-sm" id="currentStorageCapacity"
+								name="currentStorageCapacity" placeholder="250"
+								th:value="${center.currentStorageCapacity}" required />
+						</div>
+
+						<!-- 備考 -->
+						<div class="mb-2" id="custum-form">
+							<label for="notes" class="form-label">備考</label>
+							<textarea class="form-control form-control-sm" id="notes"
+								name="notes" rows="2" th:value="${center.notes}"></textarea>
+						</div>
+
+						<!-- 「＊」必須項目の説明 -->
+						<div class="mb-2" id="custum-form">
+							<span class="text-danger">*</span><span>の付いている項目は必須入力です。</span>
+						</div>
+
+
+						<!-- ボタン -->
+						<div class="d-flex justify-content-between">
+							<a href="/admin/centerInfo" class="btn btn-secondary btn-sm">キャンセル</a>
+							<div>
+								<a href="/admin/centerInfo" class="btn btn-primary btn-sm">削除する</a>
+								<button type="submit" class="btn btn-success btn-sm">
+									更新する</button>
+							</div>
+						</div>
+
+					</form>
+				</div>
+			</div>
+		</div>
+	</div>
+</body>
+</html>


### PR DESCRIPTION
## 概要

在庫センター情報の更新/削除画面を作成し、更新機能を実装

## 実装方針・詳細

- 在庫センター情報画面のセンター名のリンクから更新/削除画面へ遷移
- 更新/削除画面は選択したセンターの詳細情報が表示
- 詳細情報を修正し、更新するボタンを押下するとDBが更新される

## 影響範囲

他の機能へ影響なし

## テスト

このセクションでは、この PR に関連するテストケースやテスト方法を記載してください。

- 在庫センター情報画面のセンター名のリンクをクリックし、画面が遷移しセンターの詳細情報が表示される
- センターの詳細情報を修正し、更新するボタンを押下すると在庫センター情報画面のデータが更新されている
